### PR TITLE
Add rule to redirect / to www

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,5 @@
+# Redirect root to www
+/ https://www.bcjobs.ca 301
+
 # Force HTTPS
 http://get.bcjobs.ca/* https://get.bcjobs.ca/:splat 301!


### PR DESCRIPTION
There's current no content at the root at https://get.bcjobs.ca/.

This PR will add a redirect rule to redirect https://get.bcjobs.ca/ requests to https://www.bcjobs.ca/