### PR TITLE
Add Intercom.io widget

### DIFF
--- a/_includes/intercom.html
+++ b/_includes/intercom.html
@@ -1,0 +1,15 @@
+{% if jekyll.environment == "development" %}
+  <script>
+    window.intercomSettings = {
+      app_id: "suuy1hb0"
+    };
+  </script>
+  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/suuy1hb0';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
+{% else if jekyll.environment == "production" %}
+  <script>
+    window.intercomSettings = {
+      app_id: "gm8dj098"
+    };
+  </script>
+  <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/gm8dj098';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,5 +32,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       
       {{ content }}
     </div>
+    {% include intercom.html %}
   </body>
 </html>


### PR DESCRIPTION
Add Intercom.io widget which allows us to chat with prospects.

This checks `jekyll.environment` and loads the correct script depending on whether we're in development or  production. To set the environment variable to `production` at Netlify, I added this setting at Netlify:
![image](https://user-images.githubusercontent.com/504505/49544209-20da7680-f88f-11e8-868b-0cd154d22f79.png)