### PR TITLE
Force https on albertajobcentre

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -3,3 +3,4 @@
 
 # Force HTTPS
 http://get.bcjobs.ca/* https://get.bcjobs.ca/:splat 301!
+http://get.albertajobcentre.ca/* https://get.albertajobcentre.ca/:splat 301!


### PR DESCRIPTION
301 redirect any requests from http://get.albertajobcentre.ca/{slug} to https://get.albertajobcentre.ca/{slug}