### PR TITLE
Move intercom to the left

### DIFF
--- a/_includes/intercom.html
+++ b/_includes/intercom.html
@@ -1,14 +1,16 @@
 {% if jekyll.environment == "development" %}
   <script>
     window.intercomSettings = {
-      app_id: "suuy1hb0"
+      app_id: "suuy1hb0",
+      alignment: "left"
     };
   </script>
   <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/suuy1hb0';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
 {% else if jekyll.environment == "production" %}
   <script>
     window.intercomSettings = {
-      app_id: "gm8dj098"
+      app_id: "gm8dj098",
+      alignment: "left"
     };
   </script>
   <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/gm8dj098';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>


### PR DESCRIPTION
Relates to https://github.com/bcjobs/jobcentre-net/issues/1018

Move intercom chat box to the left to prevent it from blocking sign up form.